### PR TITLE
[Feat] #6 API Endpoint 은닉화 로직 추가, 이에 gitignore 수정

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -99,5 +99,5 @@ RefillStation/RefillStation.xcodeproj/xcuserdata/neph.xcuserdatad
 
 RefillStation/Secrets.xcconfig
 RefillStation/RefillStation/AWSS3Configuration.xcconfig
-RefillStation/RefillStation/Resources/AWSAccessKey.plist
 RefillStation/RefillStation/Resources/Secrets.xcconfig
+RefillStation/RefillStation/Resources/SecretAccessKey.plist

--- a/RefillStation/RefillStation.xcodeproj/project.pbxproj
+++ b/RefillStation/RefillStation.xcodeproj/project.pbxproj
@@ -60,7 +60,7 @@
 		3269F6DC2996AD8D00AAD8A9 /* AsyncRegisterReviewRepositoryInterface.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3269F6DB2996AD8D00AAD8A9 /* AsyncRegisterReviewRepositoryInterface.swift */; };
 		3269F6DE2996ADA700AAD8A9 /* AsyncRegisterReviewRepository.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3269F6DD2996ADA700AAD8A9 /* AsyncRegisterReviewRepository.swift */; };
 		3269F6E32998A37800AAD8A9 /* NSAttributedStringExtension.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3269F6E22998A37800AAD8A9 /* NSAttributedStringExtension.swift */; };
-		3282FED32992391C00DBFE24 /* AWSAccessKey.plist in Resources */ = {isa = PBXBuildFile; fileRef = 3282FED22992391C00DBFE24 /* AWSAccessKey.plist */; };
+		3282FED32992391C00DBFE24 /* SecretAccessKey.plist in Resources */ = {isa = PBXBuildFile; fileRef = 3282FED22992391C00DBFE24 /* SecretAccessKey.plist */; };
 		329557462951992900F5AB53 /* StoreDetailViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 32F2D9B22951864700131EB1 /* StoreDetailViewModel.swift */; };
 		329557472951992C00F5AB53 /* StoreDetailViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 32F2D9B02951862E00131EB1 /* StoreDetailViewController.swift */; };
 		329827842995422200304B68 /* UITextViewExtension.swift in Sources */ = {isa = PBXBuildFile; fileRef = 329827832995422200304B68 /* UITextViewExtension.swift */; };
@@ -289,7 +289,7 @@
 		3269F6DB2996AD8D00AAD8A9 /* AsyncRegisterReviewRepositoryInterface.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AsyncRegisterReviewRepositoryInterface.swift; sourceTree = "<group>"; };
 		3269F6DD2996ADA700AAD8A9 /* AsyncRegisterReviewRepository.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AsyncRegisterReviewRepository.swift; sourceTree = "<group>"; };
 		3269F6E22998A37800AAD8A9 /* NSAttributedStringExtension.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NSAttributedStringExtension.swift; sourceTree = "<group>"; };
-		3282FED22992391C00DBFE24 /* AWSAccessKey.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = AWSAccessKey.plist; sourceTree = "<group>"; };
+		3282FED22992391C00DBFE24 /* SecretAccessKey.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = SecretAccessKey.plist; sourceTree = "<group>"; };
 		329827832995422200304B68 /* UITextViewExtension.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UITextViewExtension.swift; sourceTree = "<group>"; };
 		3299C8912994B3F90086837F /* UILabelExtension.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UILabelExtension.swift; sourceTree = "<group>"; };
 		329E80222977FA72004286B0 /* OnboardingCollectionViewCell.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = OnboardingCollectionViewCell.swift; sourceTree = "<group>"; };
@@ -591,7 +591,7 @@
 				3244A209292DC13A00716A2B /* LaunchScreen.storyboard */,
 				3244A20C292DC13A00716A2B /* Info.plist */,
 				FCB00888299153FA0006FF53 /* Secrets.xcconfig */,
-				3282FED22992391C00DBFE24 /* AWSAccessKey.plist */,
+				3282FED22992391C00DBFE24 /* SecretAccessKey.plist */,
 			);
 			path = Resources;
 			sourceTree = "<group>";
@@ -1507,7 +1507,7 @@
 				3244A233292DC48300716A2B /* .swiftlint.yml in Resources */,
 				FCEE10232934C385002E629D /* Colors.xcassets in Resources */,
 				FCB00889299153FA0006FF53 /* Secrets.xcconfig in Resources */,
-				3282FED32992391C00DBFE24 /* AWSAccessKey.plist in Resources */,
+				3282FED32992391C00DBFE24 /* SecretAccessKey.plist in Resources */,
 				3244A20B292DC13A00716A2B /* LaunchScreen.storyboard in Resources */,
 				3244A208292DC13A00716A2B /* Assets.xcassets in Resources */,
 				FCEE10252934C855002E629D /* images.xcassets in Resources */,

--- a/RefillStation/RefillStation/Infrastructure/AWSS3Service.swift
+++ b/RefillStation/RefillStation/Infrastructure/AWSS3Service.swift
@@ -39,7 +39,7 @@ public class AWSS3Service: AWSS3ServiceInterface {
     }
 
     private var awsAccessKey: NSDictionary {
-        guard let path = Bundle.main.path(forResource: "AWSAccessKey", ofType: "plist"),
+        guard let path = Bundle.main.path(forResource: "SecretAccessKey", ofType: "plist"),
               let dictionary = NSDictionary(contentsOfFile: path) else { return [:] }
         return dictionary
     }

--- a/RefillStation/RefillStation/Infrastructure/Network/NetworkService.swift
+++ b/RefillStation/RefillStation/Infrastructure/Network/NetworkService.swift
@@ -26,7 +26,13 @@ protocol NetworkServiceInterface {
 final class NetworkService: NetworkServiceInterface {
     static let shared = NetworkService()
 
-    let baseURL = "https://www.pump-api-dev.com"
+    var baseURL: String {
+        guard let path = Bundle.main.path(forResource: "SecretAccessKey", ofType: "plist"),
+              let dictionary = NSDictionary(contentsOfFile: path),
+              let baseURL = dictionary["BASE_URL"] as? String else { return "" }
+        return baseURL
+    }
+
     private var token: String? {
         if let token = KeychainManager.shared.getItem(key: "token") as? String {
             return token


### PR DESCRIPTION
@anyukyung 
## 🧴 PR 요약
- 서버로부터의 공격에서 보호하기 위해 서버의 base url을 숨기는 작업을 진행했습니다.
  - 기존의 AWSAccessKey 파일을 SecretAccessKey 파일로 변경하였습니다.

#### Linked Issue
close #6 
