### PR TITLE
[Feat] #8 가게 상세화면에서 주소를 2줄로 표기되도록 변경

### DIFF
--- a/RefillStation/RefillStation/Presentation/StoreDetailScene/View/StoreDetailInfo/StoreDetailInfoViewCell.swift
+++ b/RefillStation/RefillStation/Presentation/StoreDetailScene/View/StoreDetailInfo/StoreDetailInfoViewCell.swift
@@ -35,8 +35,9 @@ final class StoreDetailInfoViewCell: UICollectionViewCell {
     }()
     private let storeAddressLabel: UILabel = {
         let label = UILabel()
-        label.font = UIFont.font(style: .bodyMedium)
+        label.font = UIFont.font(style: .bodyMediumOverTwoLine)
         label.textColor = Asset.Colors.gray5.color
+        label.numberOfLines = 0
         return label
     }()
     private lazy var checkVisitGuideButton: UIButton = {
@@ -96,7 +97,8 @@ final class StoreDetailInfoViewCell: UICollectionViewCell {
         contentView.frame.width - storeNameLabelInsetSum : screenWidth - storeNameLabelInsetSum
         storeNameLabel.setText(text: store.name, font: .titleLarge1OverTwoLine)
         storeNameLabel.lineBreakStrategy = .hangulWordPriority
-        storeAddressLabel.setText(text: store.address, font: .bodyMedium)
+        storeAddressLabel.setText(text: store.address, font: .bodyMediumOverTwoLine)
+        storeAddressLabel.lineBreakStrategy = .hangulWordPriority
         setUpLikeCount(response: .init(recommendCount: store.recommendedCount,
                                        didRecommended: store.didUserRecommended))
         if let storeImageURL = URL(string: store.imageURL.first ?? "") {
@@ -114,6 +116,18 @@ final class StoreDetailInfoViewCell: UICollectionViewCell {
             $0.top.equalToSuperview().inset(26)
             $0.leading.trailing.equalToSuperview().inset(16)
             $0.height.equalTo(newHeight).priority(.required)
+        }
+
+        let newSizeForAddress = storeAddressLabel.sizeThatFits(CGSize(width: targetWidth,
+                                                                      height: CGFloat.greatestFiniteMagnitude))
+        let newHeightForAddress = newSizeForAddress.height == 0 ? 17 : newSizeForAddress.height
+        storeAddressLabel.snp.remakeConstraints {
+            if storeInfoOuterView.subviews.contains(checkVisitGuideButton) {
+                $0.top.equalTo(checkVisitGuideButton.snp.bottom).offset(4).priority(.high)
+            }
+            $0.top.equalTo(storeNameLabel.snp.bottom).offset(16).priority(.low)
+            $0.leading.trailing.equalToSuperview().inset(16)
+            $0.height.equalTo(newHeightForAddress)
         }
     }
 
@@ -166,7 +180,7 @@ final class StoreDetailInfoViewCell: UICollectionViewCell {
         storeAddressLabel.snp.makeConstraints {
             $0.top.equalTo(checkVisitGuideButton.snp.bottom).offset(4).priority(.high)
             $0.top.equalTo(storeNameLabel.snp.bottom).offset(16).priority(.low)
-            $0.leading.equalTo(storeNameLabel)
+            $0.leading.trailing.equalToSuperview().inset(16)
         }
         storeStackOuterView.snp.makeConstraints {
             $0.leading.trailing.equalToSuperview().inset(16)

--- a/RefillStation/RefillStation/Presentation/StoreDetailScene/ViewController/StoreDetailViewController.swift
+++ b/RefillStation/RefillStation/Presentation/StoreDetailScene/ViewController/StoreDetailViewController.swift
@@ -398,8 +398,9 @@ extension StoreDetailViewController {
     private func storeDetailInfoCellRegisration() -> UICollectionView.CellRegistration<StoreDetailInfoViewCell, StoreDetailItem> {
         return UICollectionView
             .CellRegistration<StoreDetailInfoViewCell, StoreDetailItem> { [weak self] (cell, indexPath, item) in
-                guard case let .storeDetailInfo(store) = item else { return }
-                cell.setUpContents(store: store)
+                guard case let .storeDetailInfo(store) = item,
+                      let self = self else { return }
+                cell.setUpContents(store: store, screenWidth: self.view.frame.width)
                 cell.storeButtonTapped = { [weak self] in
                     guard let self = self else { return }
                     self.storeDetailButtonTapped(buttonType: $0)


### PR DESCRIPTION
## 🧴 PR 요약
- 가게 상세화면의 가게 정보 셀의 주소가 길어질 경우 2줄로 표기해달라는 요청을 반영했습니다.

#### 📌 변경 사항
- 주소의 폰트가 bodyMedium에서 bodyMediumOverTwoLine으로 변경되었습니다.
- cell의 frame이 원하는 타이밍에 잡히지 않는 문제로 인해 screenwidth를 매번 받도록 변경했습니다.

##### 📸 ScreenShot
![image](https://user-images.githubusercontent.com/67148595/229337090-8c108b8e-2344-45aa-b59c-8aea77d537f2.png)

#### Linked Issue
close #8 
